### PR TITLE
fix(checkout): fix indefinite loading on checkout purchase request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,9 @@
 
 Please include a summary of the changes. Please also include relevant motivation and context. List any dependencies that are required for this change or relevant affected files.
 
-- [x] Added feature X
-- [x] Fix Y causing bug Z
-
 # Type of change
 
-- [x] A new feature
-- [x] A bug fix
-- [x] Other
+Specify if this change is either one of the following: A new feature, A bug fix, Various Changes
 
 # Affected Issues
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kimitzu-client",
-  "version": "0.3.1-beta",
+  "version": "0.3.2-beta",
   "private": true,
   "author": {
     "email": "dev@kimitzu.ch",

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -358,7 +358,7 @@ class Order implements OrderInterface {
       const paymentInformation = orderRequest.data as OrderPaymentInformation
       return paymentInformation
     } catch (e) {
-      throw new Error(e.response.data.reason)
+      throw e
     }
   }
 

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -557,7 +557,6 @@ class Checkout extends Component<CheckoutProps, CheckoutState> {
         this.state.coupon
       )
     } catch (e) {
-      console.log(e.response.data)
       window.UIkit.notification(e.response.data.reason, {
         status: 'warning',
       })


### PR DESCRIPTION
# Changes

When buyer nodes cannot reach vendor nodes, sometimes OB sends an error. This commit captures that error and displays it accordingly.

# Type of change

- [ ] A new feature
- [x] A bug fix
- [ ] Other

# Affected Issues

- Fix #38